### PR TITLE
Allow hyphen in first part of URL

### DIFF
--- a/syntax/wikidot.vim
+++ b/syntax/wikidot.vim
@@ -16,7 +16,7 @@ unlet! b:current_syntax
 
 syntax match wikidotComment '\[!--.*--\]'
 syntax match wikidotElement '\[\[\([^\]]\|\n\)\+\]\]'
-syntax match wikidotLink '\(\[\[\[\([^\]]\|\n\)\+\]\]\]\|\[\w\+:\/\/\w\+\.\w\+[^\]]*\]\)'
+syntax match wikidotLink '\(\[\[\[\([^\]]\|\n\)\+\]\]\]\|\[\w\+:\/\/[\w-]\+\.\w\+[^\]]*\]\)'
 syntax match wikidotBullet '^\s*\* '
 syntax match wikidotTable '||\~\?'
 syntax match wikidotSeparator '-\{4,}'


### PR DESCRIPTION
To match URLs of the form `http://scp-wiki.wikidot.com`.

The current regex does not allow a hyphen in a part of the URL that comes before a dot (it allows any character but `\` so long as that character comes after a dot).